### PR TITLE
fix(highlight): do not override definition when `(not force?)`

### DIFF
--- a/fnl/leap.fnl
+++ b/fnl/leap.fnl
@@ -134,7 +134,7 @@ character instead."
            :ctermbg "blue"
            :nocombine true}})
   (each [name def-map (pairs def-maps)]
-    (when (not force?) (tset def-map :default true))
+    (when-not force? (tset def-map :default true))
     (api.nvim_set_hl 0 name def-map)))
 
 

--- a/fnl/leap.fnl
+++ b/fnl/leap.fnl
@@ -134,7 +134,7 @@ character instead."
            :ctermbg "blue"
            :nocombine true}})
   (each [name def-map (pairs def-maps)]
-    (when force? (tset def-map :default true))
+    (when (not force?) (tset def-map :default true))
     (api.nvim_set_hl 0 name def-map)))
 
 

--- a/lua/leap.lua
+++ b/lua/leap.lua
@@ -152,7 +152,7 @@ local function init_highlight(force_3f)
   end
   def_maps = {[hl.group.match] = {fg = _19_, ctermfg = "red", underline = true, nocombine = true}, [hl.group["label-primary"]] = {fg = "black", bg = _24_, ctermfg = "black", ctermbg = "red", nocombine = true}, [hl.group["label-secondary"]] = {fg = "black", bg = _29_, ctermfg = "black", ctermbg = "blue", nocombine = true}}
   for name, def_map in pairs(def_maps) do
-    if force_3f then
+    if not force_3f then
       def_map["default"] = true
     else
     end


### PR DESCRIPTION
Hello, @ggandor! Thank you for all your work; Leap is great (and so is Lightspeed)!

This fixes a tiny bug (introduced in eb36d7238bc2d603106631065da0b6c5779319b4) that causes user-defined highlight groups to be overridden "by default", i.e. without `force?` being `true`:

https://github.com/ggandor/leap.nvim/blob/eb36d7238bc2d603106631065da0b6c5779319b4/fnl/leap.fnl#L137

This restores the previous behaviour (22e1164223271244753da2e76812d2a1673a1ffb and older), keeping `when` instead of `if` control flow.

https://github.com/ggandor/leap.nvim/blob/22e1164223271244753da2e76812d2a1673a1ffb/fnl/leap.fnl#L148
