### PR TITLE
improved doc: keymaps to use custom `leap` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ function leap_bidirectional()
 end
 ```
 
+Then set a keymap to use the function defined. For example, the following will set `s` in normal mode to trigger `leap_bidirectional`:
+
+`vim.api.nvim_set_keymap("n", "s", ":lua leap_bidirectional()<CR>", { noremap = true, silent = true })`
+
 ### User events
 
 Leap triggers `User` events on entering/exiting (with patterns `LeapEnter` and

--- a/README.md
+++ b/README.md
@@ -255,12 +255,9 @@ function leap_bidirectional()
     ['target-windows'] = { vim.fn.getwininfo(vim.fn.win_getid())[1] }
   }
 end
-```
 
-Then set a keymap to use the function defined. For example, the following will set `s` in normal mode to trigger `leap_bidirectional`:
-
-```lua
-vim.api.nvim_set_keymap("n", "s", ":lua leap_bidirectional()<CR>", { noremap = true, silent = true })
+-- Map them to your preferred key, like:
+vim.keymap.set('n', 's', leap_all_windows, { silent = true })
 ```
 
 ### User events

--- a/README.md
+++ b/README.md
@@ -259,7 +259,9 @@ end
 
 Then set a keymap to use the function defined. For example, the following will set `s` in normal mode to trigger `leap_bidirectional`:
 
-`vim.api.nvim_set_keymap("n", "s", ":lua leap_bidirectional()<CR>", { noremap = true, silent = true })`
+```lua
+vim.api.nvim_set_keymap("n", "s", ":lua leap_bidirectional()<CR>", { noremap = true, silent = true })
+```
 
 ### User events
 


### PR DESCRIPTION
Hello ggandor!

Big fan of your `lightspeed.nvim`!

I was setting up `leap.nvim` to use `bidirectional`. In `lightspeed.nvim` using `bidirectional` is as easy as the following:
```
vim.cmd([[
nnoremap s <Plug>Lightspeed_omni_s
]])
```
But `:h leap` only shows the following:

```
<Plug>(leap-backward)
<Plug>(leap-forward-x)
<Plug>(leap-backward-x)
<Plug>(leap-cross-window)
```

I found the instruction for `bidirectional` in `README.md`. With the new lua syntax it took me some time to figure out the remapping, hence the proposed changes in `README.md` might improve the doc.
