### PR TITLE
fix: Dummy-proof README.md for init.vim users

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,13 @@ vim.api.nvim_set_hl(0, 'LeapBackdrop', { fg = '#707070' })
 ### Installation
 
 Use your preferred plugin manager. No extra steps needed, besides optionally
-setting the default keymaps:
+setting the default keymaps. In your `init.lua`, this would be:
 
 `require('leap').set_default_keymaps()`
+
+and in your `init.vim`, this would be
+
+`lua require('leap').set_default_keymaps()`
 
 ## Usage
 


### PR DESCRIPTION
There have been a few issues on this, e.g.:

- <https://github.com/ggandor/leap.nvim/issues/19>
- <https://github.com/ggandor/leap.nvim/issues/42>
- <https://github.com/ggandor/leap.nvim/issues/46>

and this also stumped me. The solution is that the require command only works in an init.lua file. This commit points that out and offers the correct command for init.vim users.