### PR TITLE
Make default config copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,13 +448,13 @@ require('leap').setup {
   substitute_chars = {},
   -- Leaving the appropriate list empty effectively disables "smart" mode,
   -- and forces auto-jump to be on or off.
-  safe_labels = { . . . },
-  labels = { . . . },
+  safe_labels = {},
+  labels = {},
   special_keys = {
     repeat_search  = '<enter>',
     next_aot_match = '<enter>',
-    next_match     = {';', '<enter>'}
-    prev_match     = {',', '<tab>'}
+    next_match     = {';', '<enter>'},
+    prev_match     = {',', '<tab>'},
     next_group     = '<space>',
     prev_group     = '<tab>',
     multi_accept   = '<enter>',


### PR DESCRIPTION
The expectation when copying the default config from the README is that it should just work. However this config had a few minor syntax issues which is cleared up by this commit.

Signed-off-by: Erik Sjöström <erikdsjostrom@gmail.com>