### PR TITLE
feat(leap): add keymap description for default mappings

### DIFF
--- a/fnl/leap/user.fnl
+++ b/fnl/leap/user.fnl
@@ -1,13 +1,13 @@
 ; Convenience functions for users.
 
 (fn add-default-mappings [force?]
-  (each [_ [modes lhs rhs]
+  (each [_ [modes lhs rhs desc]
          (ipairs
-          [[[:n :x :o] "s"  "<Plug>(leap-forward-to)"]
-           [[:n :x :o] "S"  "<Plug>(leap-backward-to)"]
-           [   [:x :o] "x"  "<Plug>(leap-forward-till)"]
-           [   [:x :o] "X"  "<Plug>(leap-backward-till)"]
-           [[:n :x :o] "gs" "<Plug>(leap-cross-window)"]])]
+          [[[:n :x :o] "s"  "<Plug>(leap-forward-to)" "Leap forward to"]
+           [[:n :x :o] "S"  "<Plug>(leap-backward-to)" "Leap backward to"]
+           [   [:x :o] "x"  "<Plug>(leap-forward-till)" "Leap forward till"]
+           [   [:x :o] "X"  "<Plug>(leap-backward-till)" "Leap backward till"]
+           [[:n :x :o] "gs" "<Plug>(leap-cross-window)" "Leap cross window"]])]
     (each [_ mode (ipairs modes)]
       (when (or force?
                 ; Otherwise only set the keymaps if:
@@ -16,7 +16,7 @@
                 ; 2. There is no existing mapping to the <Plug> key.
                 (and (= (vim.fn.mapcheck lhs mode) "")
                      (= (vim.fn.hasmapto rhs mode) 0)))
-        (vim.keymap.set mode lhs rhs {:silent true})))))
+        (vim.keymap.set mode lhs rhs {:silent true :desc desc})))))
 
 ; Deprecated.
 (fn set-default-keymaps [force?]

--- a/lua/leap/user.lua
+++ b/lua/leap/user.lua
@@ -1,12 +1,13 @@
 local function add_default_mappings(force_3f)
-  for _, _1_ in ipairs({{{"n", "x", "o"}, "s", "<Plug>(leap-forward-to)"}, {{"n", "x", "o"}, "S", "<Plug>(leap-backward-to)"}, {{"x", "o"}, "x", "<Plug>(leap-forward-till)"}, {{"x", "o"}, "X", "<Plug>(leap-backward-till)"}, {{"n", "x", "o"}, "gs", "<Plug>(leap-cross-window)"}}) do
+  for _, _1_ in ipairs({{{"n", "x", "o"}, "s", "<Plug>(leap-forward-to)", "Leap forward to"}, {{"n", "x", "o"}, "S", "<Plug>(leap-backward-to)", "Leap backward to"}, {{"x", "o"}, "x", "<Plug>(leap-forward-till)", "Leap forward till"}, {{"x", "o"}, "X", "<Plug>(leap-backward-till)", "Leap backward till"}, {{"n", "x", "o"}, "gs", "<Plug>(leap-cross-window)", "Leap cross window"}}) do
     local _each_2_ = _1_
     local modes = _each_2_[1]
     local lhs = _each_2_[2]
     local rhs = _each_2_[3]
+    local desc = _each_2_[4]
     for _0, mode in ipairs(modes) do
       if (force_3f or ((vim.fn.mapcheck(lhs, mode) == "") and (vim.fn.hasmapto(rhs, mode) == 0))) then
-        vim.keymap.set(mode, lhs, rhs, {silent = true})
+        vim.keymap.set(mode, lhs, rhs, {silent = true, desc = desc})
       else
       end
     end


### PR DESCRIPTION
So, users with `which-key` installed can have nice descriptions for `leap` mappings