### PR TITLE
fix(leap): validate buffers and windows

### DIFF
--- a/fnl/leap/highlight.fnl
+++ b/fnl/leap/highlight.fnl
@@ -20,7 +20,8 @@
 (fn M.cleanup [self affected-windows]
   ; Clear beacons & cursor.
   (each [_ [bufnr id] (ipairs self.extmarks)]
-    (api.nvim_buf_del_extmark bufnr self.ns id))
+    (if (api.nvim_buf_is_valid bufnr)
+      (api.nvim_buf_del_extmark bufnr self.ns id)))
   (set self.extmarks [])
   ; Clear backdrop.
   (when (pcall api.nvim_get_hl_by_name self.group.backdrop false)  ; group exists?

--- a/fnl/leap/main.fnl
+++ b/fnl/leap/main.fnl
@@ -361,18 +361,19 @@ is either labeled (C) or not (B).
     (local target (. targets i))
     (case target.beacon
       [offset virttext]
-      (let [bufnr target.wininfo.bufnr
-            [lnum col] (map dec target.pos)  ; 1/1 -> 0/0 indexing
-            id (api.nvim_buf_set_extmark bufnr hl.ns lnum (+ col offset)
-                                         {:virt_text virttext
-                                          :virt_text_pos "overlay"
-                                          :hl_mode "combine"
-                                          :priority hl.priority.label})]
-        ; Register each newly set extmark in a table, so that we can
-        ; delete them one by one, without needing any further contextual
-        ; information. This is relevant if we process user-given targets
-        ; and have no knowledge about the boundaries of the search area.
-        (table.insert hl.extmarks [bufnr id])))))
+      (if (api.nvim_buf_is_valid target.wininfo.bufnr)
+        (let [bufnr target.wininfo.bufnr
+              [lnum col] (map dec target.pos)  ; 1/1 -> 0/0 indexing
+              id (api.nvim_buf_set_extmark bufnr hl.ns lnum (+ col offset)
+                                           {:virt_text virttext
+                                            :virt_text_pos "overlay"
+                                            :hl_mode "combine"
+                                            :priority hl.priority.label})]
+          ; Register each newly set extmark in a table, so that we can
+          ; delete them one by one, without needing any further contextual
+          ; information. This is relevant if we process user-given targets
+          ; and have no knowledge about the boundaries of the search area.
+          (table.insert hl.extmarks [bufnr id]))))))
 
 
 ; Main ///1
@@ -945,8 +946,8 @@ is either labeled (C) or not (B).
 (fn restore-editor-opts []
   (each [key val (pairs state.saved_editor_opts)]
     (case key
-      [:w w name] (api.nvim_win_set_option w name val)
-      [:b b name] (api.nvim_buf_set_option b name val)
+      [:w w name] (if (api.nvim_win_is_valid w) (api.nvim_win_set_option w name val))
+      [:b b name] (if (api.nvim_buf_is_valid b) (api.nvim_buf_set_option b name val))
       name (api.nvim_set_option name val))))
 
 

--- a/lua/leap/highlight.lua
+++ b/lua/leap/highlight.lua
@@ -10,7 +10,10 @@ M.cleanup = function(self, affected_windows)
     local _each_3_ = _2_
     local bufnr = _each_3_[1]
     local id = _each_3_[2]
-    api.nvim_buf_del_extmark(bufnr, self.ns, id)
+    if api.nvim_buf_is_valid(bufnr) then
+      api.nvim_buf_del_extmark(bufnr, self.ns, id)
+    else
+    end
   end
   self.extmarks = {}
   if pcall(api.nvim_get_hl_by_name, self.group.backdrop, false) then

--- a/lua/leap/main.lua
+++ b/lua/leap/main.lua
@@ -349,12 +349,15 @@ local function light_up_beacons(targets, _3fstart, _3fend)
     if ((_G.type(_57_) == "table") and (nil ~= (_57_)[1]) and (nil ~= (_57_)[2])) then
       local offset = (_57_)[1]
       local virttext = (_57_)[2]
-      local bufnr = target.wininfo.bufnr
-      local _let_58_ = map(dec, target.pos)
-      local lnum = _let_58_[1]
-      local col = _let_58_[2]
-      local id = api.nvim_buf_set_extmark(bufnr, hl.ns, lnum, (col + offset), {virt_text = virttext, virt_text_pos = "overlay", hl_mode = "combine", priority = hl.priority.label})
-      table.insert(hl.extmarks, {bufnr, id})
+      if api.nvim_buf_is_valid(target.wininfo.bufnr) then
+        local bufnr = target.wininfo.bufnr
+        local _let_58_ = map(dec, target.pos)
+        local lnum = _let_58_[1]
+        local col = _let_58_[2]
+        local id = api.nvim_buf_set_extmark(bufnr, hl.ns, lnum, (col + offset), {virt_text = virttext, virt_text_pos = "overlay", hl_mode = "combine", priority = hl.priority.label})
+        table.insert(hl.extmarks, {bufnr, id})
+      else
+      end
     else
     end
   end
@@ -1239,11 +1242,17 @@ local function restore_editor_opts()
     if ((_G.type(_203_) == "table") and ((_203_)[1] == "w") and (nil ~= (_203_)[2]) and (nil ~= (_203_)[3])) then
       local w = (_203_)[2]
       local name = (_203_)[3]
-      api.nvim_win_set_option(w, name, val)
+      if api.nvim_win_is_valid(w) then
+        api.nvim_win_set_option(w, name, val)
+      else
+      end
     elseif ((_G.type(_203_) == "table") and ((_203_)[1] == "b") and (nil ~= (_203_)[2]) and (nil ~= (_203_)[3])) then
       local b = (_203_)[2]
       local name = (_203_)[3]
-      api.nvim_buf_set_option(b, name, val)
+      if api.nvim_buf_is_valid(b) then
+        api.nvim_buf_set_option(b, name, val)
+      else
+      end
     elseif (nil ~= _203_) then
       local name = _203_
       api.nvim_set_option(name, val)


### PR DESCRIPTION
This change addresses the problem with multi-window search when there's an auto-closing floating window (such as lsp hover tooltip) - when leap tries to set markers there, hover window closes automatically, leap gets exception and reaches unrecoverable state (any further attempt to use plugin produces more exceptions).

API methods `nvim_buf_is_valid` and `nvim_win_is_valid` are used to check if target buffers/windows still exist.

Way to reproduce the problem:
1. While Neovim built-in LSP hover floating window (`vim.lsp.buf.hover`) is open:
2. Run `leap()` targeting focusable windows. Exception gets thrown after a first input.

<img width="751" alt="image" src="https://user-images.githubusercontent.com/5783792/226070916-dcbc98f4-e9a1-42b6-b4df-a7e8083c8b1c.png">
