### PR TITLE
fix(util/get-enterable-windows): exclude floating windows

### DIFF
--- a/fnl/leap/util.fnl
+++ b/fnl/leap/util.fnl
@@ -38,8 +38,10 @@ character instead."
   (let [wins (api.nvim_tabpage_list_wins 0)
         curr-win (api.nvim_get_current_win)
         curr-buf (api.nvim_get_current_buf)]
-    (filter #(and (. (api.nvim_win_get_config $) :focusable)
-                  (not= $ curr-win))
+    (filter #(let [config (api.nvim_win_get_config $)]
+               (and config.focusable
+                    (= config.relative "")  ; exclude auto-closing hover popups (e.g. LSP)
+                    (not= $ curr-win)))
             wins)))
 
 

--- a/lua/leap/util.lua
+++ b/lua/leap/util.lua
@@ -45,7 +45,8 @@ local function get_enterable_windows()
   local curr_win = api.nvim_get_current_win()
   local curr_buf = api.nvim_get_current_buf()
   local function _7_(_241)
-    return ((api.nvim_win_get_config(_241)).focusable and (_241 ~= curr_win))
+    local config = api.nvim_win_get_config(_241)
+    return (config.focusable and (config.relative == "") and (_241 ~= curr_win))
   end
   return filter(_7_, wins)
 end


### PR DESCRIPTION
This change aims to fix invalid buffer/window ID exception problem when trying to use leap with auto-closing floating windows (such as LSP/DAP hover tooltips) present. It uses 'relative' field value to check if window is floating.

This is an alternative solution to #124.