### PR TITLE
docs/fix: Telescope integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ Leap can also be used by external plugins, for example
 in `telescope.nvim` to allow for quick selection between
 search results. The below config maps (normal-mode) `s` within a Telescope picker
 to use Leap to select an entry and perform the default action (i.e. `<CR>`)
-on it, and (normal-mode) `S` to only select the entry (so you can perform a different action ot it):
+on it, and (normal-mode) `S` to only select the entry (so you can perform a different action ot it).
 
 <details>
 <summary>Example: select a Telescope entry</summary>
@@ -778,6 +778,8 @@ telescope.setup {
 }
 ```
 </details>
+
+(see also [telescope-hop.nvim](https://github.com/nvim-telescope/telescope-hop.nvim)).
 
 ### Accessing the arguments passed to `leap`
 

--- a/fnl/leap/highlight.fnl
+++ b/fnl/leap/highlight.fnl
@@ -20,7 +20,7 @@
 (fn M.cleanup [self affected-windows]
   ; Clear beacons & cursor.
   (each [_ [bufnr id] (ipairs self.extmarks)]
-    (api.nvim_buf_del_extmark bufnr self.ns id))
+    (when (api.nvim_buf_is_valid bufnr) (api.nvim_buf_del_extmark bufnr self.ns id)))
   (set self.extmarks [])
   ; Clear backdrop.
   (when (pcall api.nvim_get_hl_by_name self.group.backdrop false)  ; group exists?

--- a/fnl/leap/main.fnl
+++ b/fnl/leap/main.fnl
@@ -946,8 +946,8 @@ is either labeled (C) or not (B).
 (fn restore-editor-opts []
   (each [key val (pairs state.saved_editor_opts)]
     (case key
-      [:w w name] (api.nvim_win_set_option w name val)
-      [:b b name] (api.nvim_buf_set_option b name val)
+      [:w w name] (when (api.nvim_win_is_valid w) (api.nvim_win_set_option w name val))
+      [:b b name] (when (api.nvim_buf_is_valid b) (api.nvim_buf_set_option b name val))
       name (api.nvim_set_option name val))))
 
 

--- a/lua/leap/highlight.lua
+++ b/lua/leap/highlight.lua
@@ -10,7 +10,10 @@ M.cleanup = function(self, affected_windows)
     local _each_3_ = _2_
     local bufnr = _each_3_[1]
     local id = _each_3_[2]
-    api.nvim_buf_del_extmark(bufnr, self.ns, id)
+    if api.nvim_buf_is_valid(bufnr) then
+      api.nvim_buf_del_extmark(bufnr, self.ns, id)
+    else
+    end
   end
   self.extmarks = {}
   if pcall(api.nvim_get_hl_by_name, self.group.backdrop, false) then
@@ -32,22 +35,22 @@ M["apply-backdrop"] = function(self, backward_3f, _3ftarget_windows)
       end
       return nil
     else
-      local _let_5_ = map(dec, {vim.fn.line("."), vim.fn.col(".")})
-      local curline = _let_5_[1]
-      local curcol = _let_5_[2]
-      local _let_6_ = {dec(vim.fn.line("w0")), dec(vim.fn.line("w$"))}
-      local win_top = _let_6_[1]
-      local win_bot = _let_6_[2]
-      local function _8_()
+      local _let_6_ = map(dec, {vim.fn.line("."), vim.fn.col(".")})
+      local curline = _let_6_[1]
+      local curcol = _let_6_[2]
+      local _let_7_ = {dec(vim.fn.line("w0")), dec(vim.fn.line("w$"))}
+      local win_top = _let_7_[1]
+      local win_bot = _let_7_[2]
+      local function _9_()
         if backward_3f then
           return {{win_top, 0}, {curline, curcol}}
         else
           return {{curline, inc(curcol)}, {win_bot, -1}}
         end
       end
-      local _let_7_ = _8_()
-      local start = _let_7_[1]
-      local finish = _let_7_[2]
+      local _let_8_ = _9_()
+      local start = _let_8_[1]
+      local finish = _let_8_[2]
       return vim.highlight.range(0, self.ns, self.group.backdrop, start, finish, {priority = self.priority.backdrop})
     end
   else
@@ -55,10 +58,10 @@ M["apply-backdrop"] = function(self, backward_3f, _3ftarget_windows)
   end
 end
 M["highlight-cursor"] = function(self, _3fpos)
-  local _let_11_ = (_3fpos or util["get-cursor-pos"]())
-  local line = _let_11_[1]
-  local col = _let_11_[2]
-  local pos = _let_11_
+  local _let_12_ = (_3fpos or util["get-cursor-pos"]())
+  local line = _let_12_[1]
+  local col = _let_12_[2]
+  local pos = _let_12_
   local ch_at_curpos = (util["get-char-at"](pos, {}) or " ")
   local id = api.nvim_buf_set_extmark(0, self.ns, dec(line), dec(col), {virt_text = {{ch_at_curpos, "Cursor"}}, virt_text_pos = "overlay", hl_mode = "combine", priority = self.priority.cursor})
   return table.insert(self.extmarks, {api.nvim_get_current_buf(), id})
@@ -66,43 +69,43 @@ end
 M["init-highlight"] = function(self, force_3f)
   local bg = vim.o.background
   local defaults
-  local _13_
+  local _14_
   do
-    local _12_ = bg
-    if (_12_ == "light") then
-      _13_ = "#222222"
+    local _13_ = bg
+    if (_13_ == "light") then
+      _14_ = "#222222"
     elseif true then
-      local _ = _12_
-      _13_ = "#ccff88"
+      local _ = _13_
+      _14_ = "#ccff88"
     else
-      _13_ = nil
+      _14_ = nil
     end
   end
-  local _18_
+  local _19_
   do
-    local _17_ = bg
-    if (_17_ == "light") then
-      _18_ = "#ff8877"
+    local _18_ = bg
+    if (_18_ == "light") then
+      _19_ = "#ff8877"
     elseif true then
-      local _ = _17_
-      _18_ = "#ccff88"
+      local _ = _18_
+      _19_ = "#ccff88"
     else
-      _18_ = nil
+      _19_ = nil
     end
   end
-  local _23_
+  local _24_
   do
-    local _22_ = bg
-    if (_22_ == "light") then
-      _23_ = "#77aaff"
+    local _23_ = bg
+    if (_23_ == "light") then
+      _24_ = "#77aaff"
     elseif true then
-      local _ = _22_
-      _23_ = "#99ccff"
+      local _ = _23_
+      _24_ = "#99ccff"
     else
-      _23_ = nil
+      _24_ = nil
     end
   end
-  defaults = {[self.group.match] = {fg = _13_, ctermfg = "red", underline = true, nocombine = true}, [self.group["label-primary"]] = {fg = "black", bg = _18_, ctermfg = "black", ctermbg = "red", nocombine = true}, [self.group["label-secondary"]] = {fg = "black", bg = _23_, ctermfg = "black", ctermbg = "blue", nocombine = true}, [self.group["label-selected"]] = {fg = "black", bg = "magenta", ctermfg = "black", ctermbg = "magenta", nocombine = true}}
+  defaults = {[self.group.match] = {fg = _14_, ctermfg = "red", underline = true, nocombine = true}, [self.group["label-primary"]] = {fg = "black", bg = _19_, ctermfg = "black", ctermbg = "red", nocombine = true}, [self.group["label-secondary"]] = {fg = "black", bg = _24_, ctermfg = "black", ctermbg = "blue", nocombine = true}, [self.group["label-selected"]] = {fg = "black", bg = "magenta", ctermfg = "black", ctermbg = "magenta", nocombine = true}}
   for group_name, def_map in pairs(defaults) do
     if not force_3f then
       def_map.default = true

--- a/lua/leap/main.lua
+++ b/lua/leap/main.lua
@@ -1232,11 +1232,17 @@ local function restore_editor_opts()
     if ((_G.type(_200_) == "table") and ((_200_)[1] == "w") and (nil ~= (_200_)[2]) and (nil ~= (_200_)[3])) then
       local w = (_200_)[2]
       local name = (_200_)[3]
-      api.nvim_win_set_option(w, name, val)
+      if api.nvim_win_is_valid(w) then
+        api.nvim_win_set_option(w, name, val)
+      else
+      end
     elseif ((_G.type(_200_) == "table") and ((_200_)[1] == "b") and (nil ~= (_200_)[2]) and (nil ~= (_200_)[3])) then
       local b = (_200_)[2]
       local name = (_200_)[3]
-      api.nvim_buf_set_option(b, name, val)
+      if api.nvim_buf_is_valid(b) then
+        api.nvim_buf_set_option(b, name, val)
+      else
+      end
     elseif (nil ~= _200_) then
       local name = _200_
       api.nvim_set_option(name, val)
@@ -1246,12 +1252,12 @@ local function restore_editor_opts()
   return nil
 end
 local temporary_editor_opts = {["w.conceallevel"] = 0, ["g.scrolloff"] = 0, ["w.scrolloff"] = 0, ["g.sidescrolloff"] = 0, ["w.sidescrolloff"] = 0, ["b.modeline"] = false}
-local function _202_()
+local function _204_()
   return set_editor_opts(temporary_editor_opts)
 end
-api.nvim_create_autocmd("User", {pattern = "LeapEnter", callback = _202_, group = "LeapDefault"})
-local function _203_()
+api.nvim_create_autocmd("User", {pattern = "LeapEnter", callback = _204_, group = "LeapDefault"})
+local function _205_()
   return restore_editor_opts()
 end
-api.nvim_create_autocmd("User", {pattern = "LeapLeave", callback = _203_, group = "LeapDefault"})
+api.nvim_create_autocmd("User", {pattern = "LeapLeave", callback = _205_, group = "LeapDefault"})
 return {state = state, leap = leap}


### PR DESCRIPTION
Hi, thank you so much for the effort and careful design you have put into this plugin. I have made good use of the API that you have provided to integrate this plugin with [nvim-telescope/telescope.nvim](https://github.com/nvim-telescope/telescope.nvim). This allows you to use Leap to select an entry (I mapped this to `S`) or both select and perform the default action on an entry (I mapped this to `s`):

[![asciicast](https://asciinema.org/a/hmtvdjfPqFxl0RI9NJSdwvxOP.svg)](https://asciinema.org/a/hmtvdjfPqFxl0RI9NJSdwvxOP)

This required a small fix, as there were some calls to `vim.api.nvim_buf_del_extmark`, `vim.api.nvim_buf/win_set_option` that could trigger after the telescope window/buffer were deleted (and thus result in an error), so I protected these by checking `vim.api.nvim_buf/win_is_valid` before calling them.

I have added the config to the README, though I think it may be possible to turn this into its own telescope extension so you don't have to copy any code into your config (though it seems that those are generally use to define pickers rather than libraries of keymaps; I will look into it).