### PR TITLE
docs(readme): update LeapLabelPrimary to exact colors of lightspeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,9 +269,15 @@ vim.api.nvim_set_hl(0, 'LeapMatch', {
   -- For light themes, set to 'black' or similar.
   fg = 'white', bold = true, nocombine = true,
 })
--- Of course, specify some nicer shades instead.
+
+-- Lightspeed colors
+-- primary labels: bg = "#f02077" (light theme) or "#ff2f87"  (dark theme)
+-- secondary labels: bg = "#399d9f" (light theme) or "#99ddff" (dark theme)
+-- shortcuts: bg = "#f00077", fg = "white"
+-- You might want to use either the primary label or the shortcut colors
+-- for Leap primary labels, depending on your taste.
 vim.api.nvim_set_hl(0, 'LeapLabelPrimary', {
-  bg = "#f00077", fg = "#ffffff", bold = false, nocombine = true,
+  fg = 'red', bold = true, nocombine = true,
 })
 vim.api.nvim_set_hl(0, 'LeapLabelSecondary', {
   fg = 'blue', bold = true, nocombine = true,

--- a/README.md
+++ b/README.md
@@ -269,9 +269,9 @@ vim.api.nvim_set_hl(0, 'LeapMatch', {
   -- For light themes, set to 'black' or similar.
   fg = 'white', bold = true, nocombine = true,
 })
--- Of course, specify some nicer shades instead of the default "red" and "blue".
+-- Of course, specify some nicer shades instead.
 vim.api.nvim_set_hl(0, 'LeapLabelPrimary', {
-  fg = 'red', bold = true, nocombine = true,
+  bg = "#f00077", fg = "#ffffff", bold = false, nocombine = true,
 })
 vim.api.nvim_set_hl(0, 'LeapLabelSecondary', {
   fg = 'blue', bold = true, nocombine = true,


### PR DESCRIPTION
First of all I want to thank you for this awesome plugin. I arrived here from [lightspeed](https://github.com/ggandor/lightspeed.nvim) which I think is as nice plugin as this one. 
So, if you add this configuration to LeapLabelPrimary, you'll get the same color of lightspeed which I think it is nice to put on docs for those who are migrating from lightspeed. 




![image](https://github.com/ggandor/leap.nvim/assets/40366139/f044cfc0-8070-43b3-8fc6-18e3c438359d)