### PR TITLE
Fix error with `strcharpart` for some pre-release NeoVim builds

### DIFF
--- a/fnl/leap/util.fnl
+++ b/fnl/leap/util.fnl
@@ -51,7 +51,8 @@
 
 
 (fn strcharpart [src start len]
-  (if (= (vim.fn.has "nvim-0.10") 1)
+  (local pre-release? (. (vim.version) :prerelease))
+  (if (and (not pre-release?) (= (vim.fn.has "nvim-0.10") 1))
       (vim.fn.strcharpart src start len 1)
       (vim.fn.strcharpart src start len)))
 

--- a/lua/leap/util.lua
+++ b/lua/leap/util.lua
@@ -59,7 +59,8 @@ local function __3erepresentative_char(ch)
   end
 end
 local function strcharpart(src, start, len)
-  if (vim.fn.has("nvim-0.10") == 1) then
+  local pre_release_3f = vim.version().prerelease
+  if (not pre_release_3f and (vim.fn.has("nvim-0.10") == 1)) then
     return vim.fn.strcharpart(src, start, len, 1)
   else
     return vim.fn.strcharpart(src, start, len)


### PR DESCRIPTION
NeoVim v0.10 is not out yet, and cutting edge distributions ship their own builds of latest NeoVim that may not contain some features one might expect from a full release.

This PR adds an extra check for pre-release versions of NeoVim, if one is encountered, it will omit the `skipcc` argument to make everything work.