### PR TITLE
Update readme: Add leap-by-word plugin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,3 +770,10 @@ See [leap-spooky.nvim](https://github.com/ggandor/leap-spooky.nvim).
 See [flit.nvim](https://github.com/ggandor/flit.nvim).
 
 </details>
+
+<details>
+<summary>Leap with 1 less key-stroke</summary>
+
+See [Sleepful/leap-by-word.nvim](https://github.com/Sleepful/leap-by-word.nvim).
+
+</details>


### PR DESCRIPTION
I meant to updated the other PR but it closed automatically when I synced the fork: https://github.com/ggandor/leap.nvim/pull/195