### PR TITLE
Enable leap to work as a telescope item selector that triggers a pick

### DIFF
--- a/fnl/leap/highlight.fnl
+++ b/fnl/leap/highlight.fnl
@@ -21,17 +21,16 @@
 (fn M.cleanup [self affected-windows]
   ; Clear beacons & cursor.
   (each [_ [bufnr id] (ipairs self.extmarks)]
-    (let [is-valid-buf (api.nvim_buf_is_valid bufnr)]
-        (if (is-valid-buf)
-            (api.nvim_buf_del_extmark bufnr self.ns id))))
+      (when (api.nvim_buf_is_valid bufnr)
+          (api.nvim_buf_del_extmark bufnr self.ns id)))
   (set self.extmarks [])
   ; Clear backdrop.
   (when (pcall api.nvim_get_hl_by_name self.group.backdrop false)  ; group exists?
     (each [_ winid (ipairs affected-windows)]
-      (local wininfo (. (vim.fn.getwininfo winid) 1))
-      (if (> (length wininfo) 0)
-        (api.nvim_buf_clear_namespace
-                wininfo.bufnr self.ns (dec wininfo.topline) wininfo.botline)))
+      (when (vim.api.nvim_win_is_valid winid)
+        (let [wininfo (. (vim.fn.getwininfo winid) 1)]
+          (api.nvim_buf_clear_namespace
+                  wininfo.bufnr self.ns (dec wininfo.topline) wininfo.botline))))
     ; Safety measure for scrolloff > 0: we always clean up the current view too.
     (api.nvim_buf_clear_namespace 0 self.ns
                                   (dec (vim.fn.line "w0"))

--- a/fnl/leap/highlight.fnl
+++ b/fnl/leap/highlight.fnl
@@ -21,14 +21,17 @@
 (fn M.cleanup [self affected-windows]
   ; Clear beacons & cursor.
   (each [_ [bufnr id] (ipairs self.extmarks)]
-    (api.nvim_buf_del_extmark bufnr self.ns id))
+    (let [is-valid-buf (api.nvim_buf_is_valid bufnr)]
+        (if (is-valid-buf)
+            (api.nvim_buf_del_extmark bufnr self.ns id))))
   (set self.extmarks [])
   ; Clear backdrop.
   (when (pcall api.nvim_get_hl_by_name self.group.backdrop false)  ; group exists?
     (each [_ winid (ipairs affected-windows)]
       (local wininfo (. (vim.fn.getwininfo winid) 1))
-      (api.nvim_buf_clear_namespace
-        wininfo.bufnr self.ns (dec wininfo.topline) wininfo.botline))
+      (if (> (length wininfo) 0)
+        (api.nvim_buf_clear_namespace
+                wininfo.bufnr self.ns (dec wininfo.topline) wininfo.botline)))
     ; Safety measure for scrolloff > 0: we always clean up the current view too.
     (api.nvim_buf_clear_namespace 0 self.ns
                                   (dec (vim.fn.line "w0"))

--- a/fnl/leap/main.fnl
+++ b/fnl/leap/main.fnl
@@ -832,8 +832,10 @@ char separately.
     (fn restore-editor-opts []
       (each [key val (pairs saved-editor-opts)]
         (case key
-          [:w win name] (api.nvim_win_set_option win name val)
-          [:b buf name] (api.nvim_buf_set_option buf name val)
+          [:w win name] (if (api.nvim_win_is_valid win)
+                         (api.nvim_win_set_option win name val))
+        [:b buf name] (if (api.nvim_buf_is_valid buf)
+                         (api.nvim_buf_set_option buf name val))
           name (api.nvim_set_option name val))))
 
     (api.nvim_create_autocmd "User"

--- a/fnl/leap/main.fnl
+++ b/fnl/leap/main.fnl
@@ -834,7 +834,7 @@ char separately.
         (case key
           [:w win name] (if (api.nvim_win_is_valid win)
                          (api.nvim_win_set_option win name val))
-        [:b buf name] (if (api.nvim_buf_is_valid buf)
+          [:b buf name] (if (api.nvim_buf_is_valid buf)
                          (api.nvim_buf_set_option buf name val))
           name (api.nvim_set_option name val))))
 

--- a/lua/leap/highlight.lua
+++ b/lua/leap/highlight.lua
@@ -10,13 +10,20 @@ M.cleanup = function(self, affected_windows)
     local _each_3_ = _2_
     local bufnr = _each_3_[1]
     local id = _each_3_[2]
-    api.nvim_buf_del_extmark(bufnr, self.ns, id)
+    local is_valid_buf = api.nvim_buf_is_valid(bufnr)
+    if is_valid_buf() then
+      api.nvim_buf_del_extmark(bufnr, self.ns, id)
+    else
+    end
   end
   self.extmarks = {}
   if pcall(api.nvim_get_hl_by_name, self.group.backdrop, false) then
     for _, winid in ipairs(affected_windows) do
       local wininfo = vim.fn.getwininfo(winid)[1]
-      api.nvim_buf_clear_namespace(wininfo.bufnr, self.ns, dec(wininfo.topline), wininfo.botline)
+      if (#wininfo > 0) then
+        api.nvim_buf_clear_namespace(wininfo.bufnr, self.ns, dec(wininfo.topline), wininfo.botline)
+      else
+      end
     end
     return api.nvim_buf_clear_namespace(0, self.ns, dec(vim.fn.line("w0")), vim.fn.line("w$"))
   else
@@ -32,22 +39,22 @@ M["apply-backdrop"] = function(self, backward_3f, _3ftarget_windows)
       end
       return nil
     else
-      local _let_5_ = map(dec, get_cursor_pos())
-      local curline = _let_5_[1]
-      local curcol = _let_5_[2]
-      local _let_6_ = map(dec, {vim.fn.line("w0"), vim.fn.line("w$")})
-      local win_top = _let_6_[1]
-      local win_bot = _let_6_[2]
-      local function _8_()
+      local _let_7_ = map(dec, get_cursor_pos())
+      local curline = _let_7_[1]
+      local curcol = _let_7_[2]
+      local _let_8_ = map(dec, {vim.fn.line("w0"), vim.fn.line("w$")})
+      local win_top = _let_8_[1]
+      local win_bot = _let_8_[2]
+      local function _10_()
         if backward_3f then
           return {{win_top, 0}, {curline, curcol}}
         else
           return {{curline, inc(curcol)}, {win_bot, -1}}
         end
       end
-      local _let_7_ = _8_()
-      local start = _let_7_[1]
-      local finish = _let_7_[2]
+      local _let_9_ = _10_()
+      local start = _let_9_[1]
+      local finish = _let_9_[2]
       return vim.highlight.range(0, self.ns, self.group.backdrop, start, finish, {priority = self.priority.backdrop})
     end
   else
@@ -55,17 +62,17 @@ M["apply-backdrop"] = function(self, backward_3f, _3ftarget_windows)
   end
 end
 M["highlight-cursor"] = function(self)
-  local _let_11_ = get_cursor_pos()
-  local line = _let_11_[1]
-  local col = _let_11_[2]
+  local _let_13_ = get_cursor_pos()
+  local line = _let_13_[1]
+  local col = _let_13_[2]
   local line_str = vim.fn.getline(line)
   local ch_at_curpos
   do
-    local _12_ = vim.fn.strpart(line_str, dec(col), 1, true)
-    if (_12_ == "") then
+    local _14_ = vim.fn.strpart(line_str, dec(col), 1, true)
+    if (_14_ == "") then
       ch_at_curpos = " "
-    elseif (nil ~= _12_) then
-      local ch = _12_
+    elseif (nil ~= _14_) then
+      local ch = _14_
       ch_at_curpos = ch
     else
       ch_at_curpos = nil
@@ -77,28 +84,28 @@ end
 M["init-highlight"] = function(self, force_3f)
   local bg = vim.o.background
   local defaults
-  local _14_
+  local _16_
   if (bg == "light") then
-    _14_ = "#222222"
+    _16_ = "#222222"
   else
     local _ = bg
-    _14_ = "#ccff88"
+    _16_ = "#ccff88"
   end
-  local _18_
+  local _20_
   if (bg == "light") then
-    _18_ = "#ff8877"
+    _20_ = "#ff8877"
   else
     local _ = bg
-    _18_ = "#ccff88"
+    _20_ = "#ccff88"
   end
-  local _22_
+  local _24_
   if (bg == "light") then
-    _22_ = "#77aaff"
+    _24_ = "#77aaff"
   else
     local _ = bg
-    _22_ = "#ddaadd"
+    _24_ = "#ddaadd"
   end
-  defaults = {[self.group.match] = {fg = _14_, ctermfg = "red", underline = true, nocombine = true}, [self.group["label-primary"]] = {fg = "black", bg = _18_, ctermfg = "black", ctermbg = "red", nocombine = true}, [self.group["label-secondary"]] = {fg = "black", bg = _22_, ctermfg = "black", ctermbg = "blue", nocombine = true}}
+  defaults = {[self.group.match] = {fg = _16_, ctermfg = "red", underline = true, nocombine = true}, [self.group["label-primary"]] = {fg = "black", bg = _20_, ctermfg = "black", ctermbg = "red", nocombine = true}, [self.group["label-secondary"]] = {fg = "black", bg = _24_, ctermfg = "black", ctermbg = "blue", nocombine = true}}
   for group_name, def_map in pairs(defaults) do
     if not force_3f then
       def_map.default = true

--- a/lua/leap/highlight.lua
+++ b/lua/leap/highlight.lua
@@ -10,8 +10,7 @@ M.cleanup = function(self, affected_windows)
     local _each_3_ = _2_
     local bufnr = _each_3_[1]
     local id = _each_3_[2]
-    local is_valid_buf = api.nvim_buf_is_valid(bufnr)
-    if is_valid_buf() then
+    if api.nvim_buf_is_valid(bufnr) then
       api.nvim_buf_del_extmark(bufnr, self.ns, id)
     else
     end
@@ -19,8 +18,8 @@ M.cleanup = function(self, affected_windows)
   self.extmarks = {}
   if pcall(api.nvim_get_hl_by_name, self.group.backdrop, false) then
     for _, winid in ipairs(affected_windows) do
-      local wininfo = vim.fn.getwininfo(winid)[1]
-      if (#wininfo > 0) then
+      if vim.api.nvim_win_is_valid(winid) then
+        local wininfo = vim.fn.getwininfo(winid)[1]
         api.nvim_buf_clear_namespace(wininfo.bufnr, self.ns, dec(wininfo.topline), wininfo.botline)
       else
       end

--- a/lua/leap/main.lua
+++ b/lua/leap/main.lua
@@ -971,11 +971,17 @@ local function init()
       if ((_G.type(key) == "table") and (key[1] == "w") and (nil ~= key[2]) and (nil ~= key[3])) then
         local win = key[2]
         local name = key[3]
-        api.nvim_win_set_option(win, name, val)
+        if api.nvim_win_is_valid(win) then
+          api.nvim_win_set_option(win, name, val)
+        else
+        end
       elseif ((_G.type(key) == "table") and (key[1] == "b") and (nil ~= key[2]) and (nil ~= key[3])) then
         local buf = key[2]
         local name = key[3]
-        api.nvim_buf_set_option(buf, name, val)
+        if api.nvim_buf_is_valid(buf) then
+          api.nvim_buf_set_option(buf, name, val)
+        else
+        end
       elseif (nil ~= key) then
         local name = key
         api.nvim_set_option(name, val)
@@ -984,14 +990,14 @@ local function init()
     end
     return nil
   end
-  local function _151_(_)
+  local function _153_(_)
     return set_editor_opts(temporary_editor_opts)
   end
-  api.nvim_create_autocmd("User", {pattern = "LeapEnter", callback = _151_, group = "LeapDefault"})
-  local function _152_(_)
+  api.nvim_create_autocmd("User", {pattern = "LeapEnter", callback = _153_, group = "LeapDefault"})
+  local function _154_(_)
     return restore_editor_opts()
   end
-  return api.nvim_create_autocmd("User", {pattern = "LeapLeave", callback = _152_, group = "LeapDefault"})
+  return api.nvim_create_autocmd("User", {pattern = "LeapLeave", callback = _154_, group = "LeapDefault"})
 end
 init()
 return {state = state, leap = leap}


### PR DESCRIPTION
I have the following telescope mapping, which enables me to pick a single row from a Telescope list via leap (`s`). Because the mapping picks a row in telescope, it triggers the closing of the telescope window which causes leap to not be able to find the win/buf. The error can be reproduced as follows, given the following mapping:

```
local function get_telescope_targets(prompt_bufnr)
  local pick = require("telescope.actions.state").get_current_picker(prompt_bufnr)
  local scroller = require("telescope.pickers.scroller")

  local wininfo = vim.fn.getwininfo(pick.results_win)

  local first =
    math.max(scroller.top(pick.sorting_strategy, pick.max_results, pick.manager:num_results()), wininfo[1].topline - 1)
  local last = wininfo[1].botline - 1

  local targets = {}
  for row = last, first, -1 do
    local target = {
      wininfo = wininfo[1],
      pos = { row + 1, 1 },
      row = row,
      pick = pick,
    }
    table.insert(targets, target)
  end
  return targets
end

-- under telescope mappings
{
  ["s"] = function(prompt_bufnr)
    local win = vim.api.nvim_get_current_win()

    require("leap").leap({
      targets = get_telescope_targets(prompt_bufnr),
      action = function(target)
        target.pick:set_selection(target.row)
        require("telescope.actions").select_default(prompt_bufnr)
      end,
    })
  end,
}
```

So in a telescope window, entering normal mode and pressing `s` will turn the list of telescope items into leap targets, and selecting one will pick that item.
However, since this closes the telescope window, there are 2 undefined win/buf errors inside of leap, since leap seems to not expect a leap target like a telescope item. So, I protected these statements with guard clauses, and now I'm able to leap to a telescope target without error. I felt this was appropriate because it enables further usages of leap.

Here is a video of this customization in my branch working without error:

https://github.com/ggandor/leap.nvim/assets/21133757/0d8f7f90-51e7-4633-9025-732ddc271825

