### PR TITLE
fix: vim.highlight.range no longer supports -1 column spec

### DIFF
--- a/lua/leap/highlight.lua
+++ b/lua/leap/highlight.lua
@@ -34,7 +34,7 @@ M["apply-backdrop"] = function(self, backward_3f, _3ftarget_windows)
     if _3ftarget_windows then
       for _, winid in ipairs(_3ftarget_windows) do
         local wininfo = vim.fn.getwininfo(winid)[1]
-        vim.highlight.range(wininfo.bufnr, self.ns, self.group.backdrop, {dec(wininfo.topline), 0}, {dec(wininfo.botline), -1}, {priority = self.priority.backdrop})
+        vim.highlight.range(wininfo.bufnr, self.ns, self.group.backdrop, {dec(wininfo.topline), 0}, {dec(wininfo.botline), vim.v.maxcol}, {priority = self.priority.backdrop})
       end
       return nil
     else
@@ -48,7 +48,7 @@ M["apply-backdrop"] = function(self, backward_3f, _3ftarget_windows)
         if backward_3f then
           return {{win_top, 0}, {curline, curcol}}
         else
-          return {{curline, inc(curcol)}, {win_bot, -1}}
+          return {{curline, inc(curcol)}, {win_bot, vim.v.maxcol}}
         end
       end
       local _let_9_ = _10_()


### PR DESCRIPTION
Hi there, best plugins!

Recently, I realized that BackDrop highlighting no longer works. After some deeper research, I found some clues here neovim/neovim#28986 neovim/neovim#29194 which seem to inform us that the -1 column specification no longer applies to vim.highligh.range. Not quite sure if the change as expected.

regards!